### PR TITLE
[Lint] Update Black Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==22.3.0
 flake8==3.8.4
 isort==5.6.4
 ipdb==0.13.4


### PR DESCRIPTION
#### Purpose
- Running ```./lint``` creates this error:
```
ImportError: cannot import name '_unicodefun' from 'click' (/lib/python3.10/site-packages/click/__init__.py)
```
- As specified <a href="https://github.com/pallets/click/issues/2225">here</a>, a proper fix would be updating the black to the latest version

#### Testing
- Ran this command
```
./lint.sh
```
- Output
```
All done! ✨ 🍰 ✨
2 files reformatted, 7 files left unchanged.
INFO: Analyzed target //tools/flake8:flake8 (5 packages loaded, 87 targets configured).
INFO: Found 1 target...
Target //tools/flake8:flake8 up-to-date:
  bazel-bin/tools/flake8/flake8
INFO: Elapsed time: 0.390s, Critical Path: 0.13s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
```
