### PR TITLE
handle differences between bsd and gnu sed in eject script

### DIFF
--- a/eject.sh
+++ b/eject.sh
@@ -80,4 +80,18 @@ else
 fi
 
 msg "Updating all references to ${SOURCE_ARG} to ${DEST_ARG}"
-find ${REPO_ROOT} -type f -not -path "${REPO_ROOT}/.git/*" -not -path "${REPO_ROOT}/eject.sh" -exec sed -i "" -e "s/${SOURCE_ARG}/${DEST_ARG}/g" {} \;
+
+# BSD and GNU sed handle the `-i` argument for in-place edits differently
+INPLACEOPT=(-i)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # BSD sed expects an explicit null arg to follow the -i flag. We use an
+  # array expansion to accomplish this, since otherwise it gets swallowed
+  # if quoted in any quote character.
+  INPLACEOPT=(-i "")
+fi
+
+find ${REPO_ROOT} \
+    -type f \
+    -not -path "${REPO_ROOT}/.git/*" \
+    -not -path "${REPO_ROOT}/eject.sh" \
+    -exec sed "${INPLACEOPT[@]}" -e "s/${SOURCE_ARG}/${DEST_ARG}/g" {} \;


### PR DESCRIPTION
macOS uses BSD sed out of the box, and vs GNU sed it treats the -i argument for in-place edits slightly differently. This updates the eject script to use a different argument between macOS and Linux.
