### PR TITLE
lint: fix linting of starlark files

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,8 +1,7 @@
 load("@gazelle//:def.bzl", "gazelle")
-load("@rules_python//python:defs.bzl", "py_runtime_pair")
-load("@rules_python//python:pip.bzl", "compile_pip_requirements")
-load("@rules_go//go:def.bzl", "TOOLS_NOGO", "nogo")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_go//go:def.bzl", "TOOLS_NOGO", "nogo")
+load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 # gazelle:map_kind go_binary ${project}_go_binary //tools/rules/golang:defs.bzl
 # gazelle:map_kind go_library ${project}_go_library //tools/rules/golang:defs.bzl

--- a/lint.sh
+++ b/lint.sh
@@ -24,17 +24,16 @@ BAZEL_FILES=$(find ${REPO_ROOT} -type f \
               -o -name "*.BUILD" \
               -o -name "BUILD.*.bazel" \
               -o -name "BUILD.*.oss" \
+              -o -name "MODULE.bazel" \
               -o -name "WORKSPACE" \
               -o -name "WORKSPACE.bazel" \
               -o -name "WORKSPACE.oss" \
               -o -name "WORKSPACE.*.bazel" \
               -o -name "WORKSPACE.*.oss" \) \
-              -o -name "MODULE.bazel" \
               -print)
-BUILDIFIER_ARGS=("-mode=fix" "-v=false")
+BUILDIFIER_ARGS=("-lint=fix" "-mode=fix" "-v=false")
 BUILDIFIER_INVOCATION="bazel run -- //tools/buildifier ${BUILDIFIER_ARGS[@]}"
 echo $BAZEL_FILES | xargs ${BUILDIFIER_INVOCATION}
-
 
 #################
 # Python linting
@@ -46,7 +45,6 @@ bazel run -- //tools/black ${REPO_ROOT}
 # Ensure flake8 compliance
 bazel run -- //tools/flake8 ${REPO_ROOT}
 
-
 #################
 # Go linting
 #################
@@ -54,7 +52,6 @@ GO_FILES=$(find ${REPO_ROOT} -type f -name "*.go" -print)
 GOFMT_ARGS=("")
 GOFMT_INVOCATION="bazel run -- @rules_go//go fmt ${GOFMT_ARGS[@]}"
 echo $GO_FILES | xargs ${GOFMT_INVOCATION}
-
 
 #################
 # Markdown Linting

--- a/project/BUILD
+++ b/project/BUILD
@@ -1,4 +1,3 @@
-load("@pip//:requirements.bzl", "requirement")
 load("//tools/rules/python:defs.bzl", "${project}_py_binary", "${project}_py_image", "${project}_py_test")
 
 # gazelle:prefix github.com/example/${project}

--- a/project/golang-example/BUILD
+++ b/project/golang-example/BUILD
@@ -1,4 +1,4 @@
-load("//tools/rules/golang:defs.bzl", "${project}_go_binary", "${project}_go_library", "${project}_go_test", "${project}_go_image")
+load("//tools/rules/golang:defs.bzl", "${project}_go_binary", "${project}_go_image", "${project}_go_library", "${project}_go_test")
 
 ${project}_go_library(
     name = "golang-example_lib",

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -1,4 +1,3 @@
-
 platform(
     name = "container_aarch64_linux",
     constraint_values = [

--- a/tools/rules/golang/defs.bzl
+++ b/tools/rules/golang/defs.bzl
@@ -69,6 +69,7 @@ def _go_layers(name, binary):
     Returns:
         A list of labels for the generated layers, which are tar files.
     """
+
     # The order of the layers here should be from least to most frequently changing.
     layers = ["app"]
 
@@ -147,6 +148,7 @@ def ${project}_go_image(name, binary, image_tags, include_runfiles = True, tars 
         workspace_path = binary.split(":")[0][2:]
     else:
         workspace_path = native.package_name()
+
     # Outputs from go_binary targets add an extra directory with a random underscore to the path
     entrypoint = entrypoint or ["/{}/{}_/{}".format(workspace_path, bin_name, bin_name)]
 

--- a/tools/rules/python/defs.bzl
+++ b/tools/rules/python/defs.bzl
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "mtree_spec", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 # These rules exist primarily as a way to provide a simple `main` wrapper for
 # py_test rules, so we don't have to provide a main stub for every test target.
@@ -74,6 +74,7 @@ def _py_layers(name, binary):
     Returns:
         A list of labels for the layers, which are tar files
     """
+
     # Produce layers in this order, as the app changes most often
     layers = ["interpreter", "packages", "app"]
 
@@ -160,6 +161,7 @@ def ${project}_py_image(name, binary, image_tags, tars = [], base = None, entryp
             image_tags = ["my-tag:latest"],
         )
     """
+
     # NOTE: We would ideally use the @distroless_base image here, which is about 140MB smaller,
     # but rules_python depends on the host python toolchain to start a py_binary, so we need to
     # use a base image that ships python.


### PR DESCRIPTION
Starlark linting got quietly broken when switching to bzlmod due to a grouping issue in the `find` expression to find these files. This fixes that lint script error and the missed lint issues since then